### PR TITLE
Fix tag formatting for blog posts

### DIFF
--- a/_posts/2025-01-04-simple-perceptron.md
+++ b/_posts/2025-01-04-simple-perceptron.md
@@ -2,7 +2,9 @@
 layout: post
 title: "Simple Perceptron Notebook"
 date: 2025-01-04 19:00:00 +0200
-tags: machine learning, perceptron
+tags:
+  - machine learning
+  - perceptron
 ---
 
 The best way to dive into the foundational concepts of machine learning is through a practical implementation of the perceptron algorithm. This notebook builds on Frank Rosenblatt’s seminal 1958 paper, _“The Perceptron: A Probabilistic Model for Information Storage and Organization in the Brain”_, and provides a hands-on guide to understanding and implementing this key algorithm.

--- a/_posts/2025-01-07-numpy-vs-python.md
+++ b/_posts/2025-01-07-numpy-vs-python.md
@@ -2,7 +2,10 @@
 layout: post
 title: "NumPy vs Loops: Performance Analysis"
 date: 2025-01-07 10:00:00 +0200
-tags: python, numpy, performance
+tags:
+  - python
+  - numpy
+  - performance
 ---
 
 When it comes to numerical computations in Python, understanding the performance trade-offs between vectorized operations and traditional loops is crucial. This short notebook explores the efficiency of NumPy against standard Python loops, offering a practical perspective on why NumPy is the go-to library for numerical computing.


### PR DESCRIPTION
## Summary
- fix tag format in `_posts/2025-01-04-simple-perceptron.md`
- fix tag format in `_posts/2025-01-07-numpy-vs-python.md`

## Testing
- `jekyll build` *(fails: cannot load such file -- jekyll-remote-theme)*

------
https://chatgpt.com/codex/tasks/task_e_68846de52e3c8329be2bd50ca2a7cc6f